### PR TITLE
Sort mbs by sender shard ID

### DIFF
--- a/process/notifier/sovereignNotifier.go
+++ b/process/notifier/sovereignNotifier.go
@@ -172,6 +172,9 @@ func (notifier *sovereignNotifier) createIncomingMbsFromTxs(txs map[string]*outp
 		})
 	}
 
+	sort.SliceStable(mbs, func(i, j int) bool {
+		return mbs[i].SenderShardID < mbs[j].SenderShardID
+	})
 	return mbs, nil
 }
 

--- a/process/notifier/sovereignNotifier.go
+++ b/process/notifier/sovereignNotifier.go
@@ -128,13 +128,13 @@ func (notifier *sovereignNotifier) createAllIncomingMbs(txPool *outport.Transact
 	}
 
 	// TODO: when specs are defined, we should also handle scrs mbs
-	mbs = append(mbs, txsMb)
+	mbs = append(mbs, txsMb...)
 	return mbs, nil
 }
 
-func (notifier *sovereignNotifier) createIncomingMbsFromTxs(txs map[string]*outport.TxInfo) (*block.MiniBlock, error) {
-	txHashes := make([][]byte, 0)
+func (notifier *sovereignNotifier) createIncomingMbsFromTxs(txs map[string]*outport.TxInfo) ([]*block.MiniBlock, error) {
 	execOrderTxHashMap := make(map[string]uint32)
+	shardIDTxHashMap := make(map[uint32][][]byte)
 
 	for txHash, tx := range txs {
 		receiver := tx.GetTransaction().GetRcvAddr()
@@ -150,21 +150,29 @@ func (notifier *sovereignNotifier) createIncomingMbsFromTxs(txs map[string]*outp
 
 		log.Info("found incoming tx", "tx hash", txHash, "receiver", hex.EncodeToString(receiver))
 
-		txHashes = append(txHashes, hashBytes)
 		execOrderTxHashMap[string(hashBytes)] = tx.GetExecutionOrder()
+
+		sender := tx.GetTransaction().GetSndAddr()
+		senderShardID := notifier.shardCoordinator.ComputeId(sender)
+		shardIDTxHashMap[senderShardID] = append(shardIDTxHashMap[senderShardID], hashBytes)
 	}
 
-	sort.SliceStable(txHashes, func(i, j int) bool {
-		return execOrderTxHashMap[string(txHashes[i])] < execOrderTxHashMap[string(txHashes[j])]
-	})
+	mbs := make([]*block.MiniBlock, 0, len(shardIDTxHashMap))
+	for shardID, txHashesInShard := range shardIDTxHashMap {
+		sort.SliceStable(txHashesInShard, func(i, j int) bool {
+			return execOrderTxHashMap[string(txHashesInShard[i])] < execOrderTxHashMap[string(txHashesInShard[j])]
+		})
 
-	return &block.MiniBlock{
-		TxHashes:        txHashes,
-		ReceiverShardID: core.SovereignChainShardId,
-		SenderShardID:   0, // todo: Compute sender shard id and fill it here
-		Type:            block.TxBlock,
-		Reserved:        nil,
-	}, nil
+		mbs = append(mbs, &block.MiniBlock{
+			TxHashes:        txHashesInShard,
+			ReceiverShardID: core.SovereignChainShardId,
+			SenderShardID:   shardID,
+			Type:            block.TxBlock,
+			Reserved:        nil,
+		})
+	}
+
+	return mbs, nil
 }
 
 func (notifier *sovereignNotifier) getHeaderV2(headerType core.HeaderType, headerBytes []byte) (*block.HeaderV2, error) {

--- a/process/notifier/sovereignNotifier_test.go
+++ b/process/notifier/sovereignNotifier_test.go
@@ -83,6 +83,10 @@ func TestNewSovereignNotifier(t *testing.T) {
 func TestSovereignNotifier_Notify(t *testing.T) {
 	t.Parallel()
 
+	sender1 := []byte("sender1")
+	sender2 := []byte("sender2")
+	sender3 := []byte("sender3")
+
 	addr1 := []byte("addr1")
 	addr2 := []byte("addr2")
 	addr3 := []byte("addr3")
@@ -91,6 +95,8 @@ func TestSovereignNotifier_Notify(t *testing.T) {
 	txHash2 := []byte("hash2")
 	txHash3 := []byte("hash3")
 	txHash4 := []byte("hash4")
+	txHash5 := []byte("hash5")
+	txHash6 := []byte("hash6")
 
 	headerV2 := &block.HeaderV2{
 		Header:            &block.Header{},
@@ -103,6 +109,13 @@ func TestSovereignNotifier_Notify(t *testing.T) {
 				TxHashes:        [][]byte{txHash2, txHash3, txHash1},
 				ReceiverShardID: core.SovereignChainShardId,
 				SenderShardID:   0,
+				Type:            block.TxBlock,
+				Reserved:        nil,
+			},
+			{
+				TxHashes:        [][]byte{txHash5, txHash6},
+				ReceiverShardID: core.SovereignChainShardId,
+				SenderShardID:   1,
 				Type:            block.TxBlock,
 				Reserved:        nil,
 			},
@@ -126,6 +139,19 @@ func TestSovereignNotifier_Notify(t *testing.T) {
 
 	args := createArgs()
 	args.SubscribedAddresses = [][]byte{addr1, addr2}
+	args.ShardCoordinator = &testscommon.ShardCoordinatorStub{
+		ComputeIdCalled: func(address []byte) uint32 {
+			switch string(address) {
+			case string(sender1), string(sender2):
+				return 0
+			case string(sender3):
+				return 1
+			default:
+				require.Fail(t, "should have only 3 senders")
+				return 0xFF
+			}
+		},
+	}
 
 	sn, _ := NewSovereignNotifier(args)
 	_ = sn.RegisterHandler(handler1)
@@ -144,26 +170,44 @@ func TestSovereignNotifier_Notify(t *testing.T) {
 				hex.EncodeToString(txHash1): {
 					Transaction: &transaction.Transaction{
 						RcvAddr: addr1,
+						SndAddr: sender1,
 					},
 					ExecutionOrder: 3,
 				},
 				hex.EncodeToString(txHash2): {
 					Transaction: &transaction.Transaction{
 						RcvAddr: addr1,
+						SndAddr: sender2,
 					},
 					ExecutionOrder: 1,
 				},
 				hex.EncodeToString(txHash3): {
 					Transaction: &transaction.Transaction{
 						RcvAddr: addr2,
+						SndAddr: sender1,
 					},
 					ExecutionOrder: 2,
 				},
 				hex.EncodeToString(txHash4): {
 					Transaction: &transaction.Transaction{
 						RcvAddr: addr3,
+						SndAddr: sender2,
 					},
 					ExecutionOrder: 0,
+				},
+				hex.EncodeToString(txHash5): {
+					Transaction: &transaction.Transaction{
+						RcvAddr: addr1,
+						SndAddr: sender3,
+					},
+					ExecutionOrder: 0,
+				},
+				hex.EncodeToString(txHash6): {
+					Transaction: &transaction.Transaction{
+						RcvAddr: addr1,
+						SndAddr: sender3,
+					},
+					ExecutionOrder: 3,
 				},
 			},
 		},

--- a/testscommon/shardCoordinatorStub.go
+++ b/testscommon/shardCoordinatorStub.go
@@ -2,10 +2,14 @@ package testscommon
 
 // ShardCoordinatorStub -
 type ShardCoordinatorStub struct {
+	ComputeIdCalled func(address []byte) uint32
 }
 
 // ComputeId -
-func (scs *ShardCoordinatorStub) ComputeId(_ []byte) uint32 {
+func (scs *ShardCoordinatorStub) ComputeId(address []byte) uint32 {
+	if scs.ComputeIdCalled != nil {
+		return scs.ComputeIdCalled(address)
+	}
 	return 0
 }
 


### PR DESCRIPTION
- Before this PR, all tx hashes were included in the same mb.
- Grouped and sorted incoming mbs by sender shard ID. 
